### PR TITLE
Update READMEs

### DIFF
--- a/README
+++ b/README
@@ -24,10 +24,9 @@ to get later time steps.  You should see a picture like
   Examples/Ellipsis3D_2004_examples/chemical_plume.jpg
 
 
-Please submit bug reports via the World Wide Web at:
-    http://geodynamics.org/roundup    
+Please submit bug reports by opening an issue on the geodynamics/ellipsis3d Github reposity. 
 
-Please send all questions by electronic mail to:
-    cig-mc@geodynamics.org
+Please send all questions to the geodynamics forum at:
+https://community.geodynamics.org/
 
 Ellipsis3D is free software.  See the file COPYING for copying conditions.

--- a/README
+++ b/README
@@ -24,7 +24,7 @@ to get later time steps.  You should see a picture like
   Examples/Ellipsis3D_2004_examples/chemical_plume.jpg
 
 
-Please submit bug reports by opening an issue on the geodynamics/ellipsis3d Github reposity. 
+Please submit bug reports by opening an issue on the geodynamics/ellipsis3d GitHub repository. 
 
 Please send all questions to the geodynamics forum at:
 https://community.geodynamics.org/

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -3,3 +3,5 @@ This container hosts a built version of ellipsis3d.
 docker run -it --rm -v $HOME/ellipsis3d:/home/ellipsis3d_user/work geodynamics/ellipsis3d
 
 This command will start the ellipsis3d docker image and give you terminal access. Any changes made in the /home/ellipsis3d_user/work directory will be reflected on the host machine at home/ellipsis3d.
+
+OpenDX is no longer maintained, so the docker container has not been verified against the test data.


### PR DESCRIPTION
Updated old references to roundup and the CIG email on the main readme, which now points to github issues and the CIG forum.

Added a disclaimer to the docker readme explaining that it has not been verified against the test data since Opendx is no longer maintained.